### PR TITLE
Added text option so you can have numbered/lettered markers

### DIFF
--- a/dist/leaflet.awesome-markers.css
+++ b/dist/leaflet.awesome-markers.css
@@ -35,11 +35,17 @@ Version: 1.0
  }
 }
 
-.awesome-marker i {
+.awesome-marker i,
+.awesome-marker strong {
   color: #333;
   margin-top: 10px;
   display: inline-block;
   font-size: 14px;
+}
+
+.awesome-marker strong {
+  width: 30px;
+  text-align: center;
 }
 
 .awesome-marker .icon-white {

--- a/dist/leaflet.awesome-markers.js
+++ b/dist/leaflet.awesome-markers.js
@@ -39,7 +39,7 @@ L.AwesomeMarkers.Icon = L.Icon.extend({
       div.innerHTML = this._createInner();
     }
 
-    if (options.text) {
+    if (options.text != undefined) {
       div.innerHTML = this._createInnerText();
     }
 

--- a/dist/leaflet.awesome-markers.js
+++ b/dist/leaflet.awesome-markers.js
@@ -39,6 +39,10 @@ L.AwesomeMarkers.Icon = L.Icon.extend({
       div.innerHTML = this._createInner();
     }
 
+    if (options.text) {
+      div.innerHTML = this._createInnerText();
+    }
+
     if (options.bgPos) {
       div.style.backgroundPosition =
               (-options.bgPos.x) + 'px ' + (-options.bgPos.y) + 'px';
@@ -58,6 +62,20 @@ L.AwesomeMarkers.Icon = L.Icon.extend({
     return "<i class='" + iconClass 
     + (this.options.spin ? " icon-spin" :"") 
     + (this.options.iconColor ? " icon-" + this.options.iconColor :"") + "'></i>";
+  },
+
+  _createInnerText: function() {
+    if (this.options.textFormat != undefined && this.options.textFormat == 'letter') {
+      this.options.text = this.num2letter(this.options.text);
+    }
+    return "<strong class='"
+    + (this.options.spin ? " icon-spin" :"") 
+    + (this.options.iconColor ? " icon-" + this.options.iconColor :"") + "'>" + this.options.text + "</strong>";
+  },
+
+  num2letter: function(num) {
+    var base = 'A'.charCodeAt(0);
+    return num < 26 ? String.fromCharCode(num + base) : String.fromCharCode(base + Math.floor(num/26) -1, base + num%26);   
   },
 
   _setIconStyles: function (img, name) {


### PR DESCRIPTION
I wanted to create numbered and lettered markers rather than using fontawesome icons.  This fork adds support for a text option that you can use instead of icon when calling L.AwesomeMarkers.icon.  It also adds a textFormat option.  If textFormat = 'letter', a number is converted to a letter and displayed in the marker (0=A, 27=AA, etc).

Example usage:

num = 1;
var marker = L.marker([item.Latitude, item.Longitude], {
  icon: L.AwesomeMarkers.icon({
    text: num,
    textFormat: 'letter',
    color: 'blue'
  }),
});

// The letter used in the marker (B)
console.log(marker.options.icon.num2letter(num));
