### PR TITLE
add fa-inverse for font-awesome instead of icon-white

### DIFF
--- a/dist/leaflet.awesome-markers.js
+++ b/dist/leaflet.awesome-markers.js
@@ -69,8 +69,11 @@
             }
 
             if(options.iconColor) {
-                if(options.iconColor === 'white' || options.iconColor === 'black') {
+                if(options.iconColor === 'white' || options.iconColor === 'black' &&
+                    options.prefix !== 'fa') {
                     iconColorClass = "icon-" + options.iconColor;
+                } else if (options.prefix === 'fa' && options.iconColor === 'white') {
+                  iconColorClass = "fa-inverse";
                 } else {
                     iconColorStyle = "style='color: " + options.iconColor + "' ";
                 }

--- a/dist/leaflet.awesome-markers.js
+++ b/dist/leaflet.awesome-markers.js
@@ -69,7 +69,7 @@
             }
 
             if(options.iconColor) {
-                if(options.iconColor === 'white' || options.iconColor === 'black' &&
+                if ((options.iconColor === 'white' || options.iconColor === 'black') &&
                     options.prefix !== 'fa') {
                     iconColorClass = "icon-" + options.iconColor;
                 } else if (options.prefix === 'fa' && options.iconColor === 'white') {


### PR DESCRIPTION
Hi Lennard,

Today I wanted to upgrade to v2.0. Thanks for all the work you put into that. But I saw that my fa icons never turned white. 
So I added this. I don't know which uglifier you use though. So I only changed the src file.

Cheers,

Fritz
